### PR TITLE
Extending the SASS presicison up to 8 digits.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ var css = {
     watch: source + 'scss/**/*',
     sassOpts: {
         outputStyle: 'nested',
-        precison: 3,
+        precision: 8,
         errLogToConsole: true,
         includePaths: [bootstrapSass.in + 'assets/stylesheets']
     }


### PR DESCRIPTION
Bootstrap is using 8 digits for some CSS values (like line-height).
